### PR TITLE
minor rewording

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ repository: "https://github.com/turbot/steampipe-mod-aws-well-architected"
 
 # AWS Well-Architected Mod
 
-Run controls across all of your AWS accounts to check if they are following AWS Well-Architected Framework best practices using Steampipe.
+Run controls across all of your AWS accounts to check if they are following AWS Well-Architected Framework best practices.
 
 <img src="https://raw.githubusercontent.com/turbot/steampipe-mod-aws-well-architected/main/docs/aws_well_architected_dashboard.png" width="50%" type="thumbnail"/>
 <img src="https://raw.githubusercontent.com/turbot/steampipe-mod-aws-well-architected/main/docs/aws_well_architected_reliability_pillar_dashboard.png" width="50%" type="thumbnail"/>


### PR DESCRIPTION
Ambiguous as written -- "Run controls across all of your AWS accounts to check if they are following AWS Well-Architected Framework best practices using Steampipe." -- because it can sound like Steampipe is being used to follow best practices, vs assess the degree to which they are being followed. It's simpler and clearer to delete "using Steampipe".

